### PR TITLE
Deliver the did-fail-load to the user again

### DIFF
--- a/examples/static/main.js
+++ b/examples/static/main.js
@@ -1,4 +1,5 @@
 var electronify = require('../../index');
+var retries = 3;
 
 electronify({
   command: 'node',
@@ -13,7 +14,26 @@ electronify({
   preLoad: function(app, window){
     // window event listeners could be added here
   },
-  postLoad: function(app, window){
+  postLoad: function(app, window, error){
+    // Error only exists if there was an error while loading
+    // error == {
+    //   event: event,
+    //   errorCode: errorCode,
+    //   errorDescription: errorDescription,
+    //   validatedURL: validatedURL,
+    //   isMainFrame: isMainFrame
+    // }
+    if (error) {
+      console.log(errorCode, errorDescription, validatedURL);
+      if (retries != 0) {
+        setTimeout(function() {
+          window.loadURL(this.url)
+          retries--
+        }, 1000);
+      }
+      return;
+    }
+
     // url finished loading
   },
   showDevTools: false

--- a/examples/static/main.js
+++ b/examples/static/main.js
@@ -1,5 +1,4 @@
 var electronify = require('../../index');
-var retries = 3;
 
 electronify({
   command: 'node',
@@ -24,14 +23,7 @@ electronify({
     //   isMainFrame: isMainFrame
     // }
     if (error) {
-      console.log(errorCode, errorDescription, validatedURL);
-      if (retries != 0) {
-        setTimeout(function() {
-          window.loadURL(this.url)
-          retries--
-        }, 1000);
-      }
-      return;
+      console.log(error.errorCode, error.errorDescription, error.validatedURL);
     }
 
     // url finished loading

--- a/index.js
+++ b/index.js
@@ -117,6 +117,8 @@ function start(cfg, app, childProcess, debug) {
   });
 
   window.webContents.on('did-fail-load', function(event, errorCode, errorDescription, validatedURL, isMainFrame) {
+    debug('Loading failed.');
+
     var error = {
       event: event,
       errorCode: errorCode,
@@ -124,6 +126,7 @@ function start(cfg, app, childProcess, debug) {
       validatedURL: validatedURL,
       isMainFrame: isMainFrame
     }
+
     if (cfg.postLoad) cfg.postLoad(app, window, error);
   });
 

--- a/index.js
+++ b/index.js
@@ -116,8 +116,15 @@ function start(cfg, app, childProcess, debug) {
     window.show();
   });
 
-  window.webContents.on('did-fail-load', function() {
-      console.log(arguments);
+  window.webContents.on('did-fail-load', function(event, errorCode, errorDescription, validatedURL, isMainFrame) {
+    var error = {
+      event: event,
+      errorCode: errorCode,
+      errorDescription: errorDescription,
+      validatedURL: validatedURL,
+      isMainFrame: isMainFrame
+    }
+    if (cfg.postLoad) cfg.postLoad(app, window, error);
   });
 
   // Clean resource


### PR DESCRIPTION
Hi!
Awesome work here. I'm sure this package will help me running a Hapi server together with electron without the need of separate services.

I had one problem with running Hapi with this.
The boot time of Hapi takes some time and before that the `window.loadURL` call is already done. This caused the need to refresh.
I figured it would be good to deliver this message back to the user again so that the user can decide what to do after that error.

This commit is backwards compatible to not force everyone to rebuild their app to catch this error.
I also update the static example with a bit more description.

For future reference if you would like to try loading the URL again do something like this:

``` javascript
var retries = 3;

electronify({
  // Your other parameters
  postLoad: function(app, window, error) {
    // console.log(arguments);
    if (error) {
      console.log(error.errorCode, error.errorDescription, error.validatedURL);
      if (retries != 0) {
        setTimeout(() => {
          // electronify(this);
          window.loadURL(this.url);
          retries--
        }, 1000);
      }
    }
  }
})
```

I hope you like what I'm doing here, if not let me know and we can discuss this a bit further.
