### PR TITLE
Add health check for server before client loads URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,15 @@ function start(cfg, app, childProcess, debug) {
   // window and app event handlers could also be added here
   if (cfg.preLoad) cfg.preLoad(app, window);
 
-  // load url
-  window.loadURL(cfg.url);
+  // health check to verify server started
+  if (cfg.healthCheck) {
+    cfg.healthCheck(app, window, function() {
+      window.loadURL(cfg.url);
+    })
+  } else {
+    // load url
+    window.loadURL(cfg.url);
+  }
 
   window.webContents.on('did-finish-load', function() {
     debug('Finished loading.');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electronify-server",
-  "version": "0.1.4",
+  "version": "0.5.1",
   "description": "electronify-server is a tool which presents local web servers in an Electron shell.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This branch adds a health check to the config object which allows for server health checks before the window loads the page.

**Example:**

This is _one_ way to do it.

``` js
var retries = 10;
var URL = 'http://127.0.0.1:8080';

// performHealthCheck queries the server and reports back if it has started yet
function performHealthCheck(done) {
    http.get(URL, (res) => {
        res.resume();
        done(true);
    }).on('error', (e) => {
        DEBUG("Server hasn't started.");
        done(false);
    });
}

electronify({
    // query the server immediately and on failure for a maximum of 10 retries
    healthCheck: function(app, window, loadWindow) {
        // check server immediately
        performHealthCheck(function(healthy) {
            if (healthy) {
                loadWindow();
            } else {

                // check server every second until max retries.
                var timeout = setInterval(function() {
                    performHealthCheck(function(healthy) {
                        if (healthy) {
                            clearInterval(timeout);
                            loadWindow();
                        } else if (!healthy && !retries) {
                            clearInterval(timeout);

                            // Display message
                            dialog.showErrorBox("Timeout!", "The client took more than 10 seconds to start!\n");

                            // close electron if the server never starts
                            app.quit();
                        }
                        retries--;
                    });
                }, 1000);
            }
        });
    },

    // more config ...
})
```
